### PR TITLE
Allow topic and otherwise comparisons to use "endswith".

### DIFF
--- a/fedbadges/rules.py
+++ b/fedbadges/rules.py
@@ -207,7 +207,10 @@ class Trigger(AbstractTopLevelComparator):
             # TODO -- use fedmsg.meta.msg2processor(msg).__name__.lower()
             return msg['topic'].split('.')[3] == self.expected_value
         else:
-            return msg[self.attribute] == self.expected_value
+            if hasattr(msg[self.attribute], 'endswith'):
+                return msg[self.attribute].endswith(self.expected_value)
+            else:
+                return msg[self.attribute] == self.expected_value
 
 
 class Criteria(AbstractTopLevelComparator):


### PR DESCRIPTION
This will be convenient especially for topics.  Instead of having
to define:

```
trigger:
    topic: org.fedoraproject.stg.bodhi.update.request.testing
```

In one badge, and then _redefine_ in another:

```
trigger:
    topic: org.fedoraproject.prod.bodhi.update.request.testing
```

With this we can just define one badge rule with:

```
trigger:
    topic: bodhi.update.request.testing
```
