### PR TITLE
Limit the awarding of badges to only FAS users.

### DIFF
--- a/fedbadges/rules.py
+++ b/fedbadges/rules.py
@@ -28,8 +28,9 @@ from fedbadges.utils import (
     recursive_lambda_factory,
     graceful,
 
-    # This makes a network API call
+    # These make networked API calls
     get_pkgdb_packages_for,
+    user_exists_in_fas,
 )
 
 import logging
@@ -207,6 +208,13 @@ class BadgeRule(object):
         # Check our backend criteria -- likely, perform datanommer queries.
         if not self.criteria.matches(msg):
             return set()
+
+        # Lastly, and this is probably most expensive.  Make sure the person
+        # actually has a FAS account before we award anything.
+        # https://github.com/fedora-infra/tahrir/issues/225
+        awardees = set([
+            u for u in awardees if user_exists_in_fas(fedmsg_config, u)
+        ])
 
         return awardees
 

--- a/fedbadges/utils.py
+++ b/fedbadges/utils.py
@@ -6,6 +6,7 @@ import logging
 log = logging.getLogger("moksha.hub")
 
 import fedmsg
+import fedora.client.fas2
 import requests
 
 # This is used for our queries against pkgdb
@@ -115,6 +116,16 @@ def notification_callback(topic, msg):
         topic=topic,
         msg=msg,
     )
+
+
+def user_exists_in_fas(config, user):
+    """ Return true if the user exists in FAS. """
+
+    fas2 = fedora.client.fas2.AccountSystem(
+        username=config['fas_credentials']['username'],
+        password=config['fas_credentials']['password'],
+    )
+    return bool(fas2.person_by_username(user))
 
 
 def get_pkgdb_packages_for(config, user):

--- a/tests/test_complicated_recipient.py
+++ b/tests/test_complicated_recipient.py
@@ -62,4 +62,6 @@ class TestComplicatedRecipient(unittest.TestCase):
         get_person.return_value = MockPerson()
         assertion_exists.return_value = False
 
-        eq_(self.rule.matches(msg), set(['zodbot', 'threebean']))
+        with patch("fedbadges.rules.user_exists_in_fas") as g:
+            g.return_value = True
+            eq_(self.rule.matches(msg), set(['zodbot', 'threebean']))

--- a/tests/test_complicated_trigger.py
+++ b/tests/test_complicated_trigger.py
@@ -113,4 +113,6 @@ class TestComplicatedTrigger(unittest.TestCase):
         get_person.return_value = MockPerson()
         assertion_exists.return_value = False
 
-        eq_(self.rule.matches(msg), set(['ralph']))
+        with patch("fedbadges.rules.user_exists_in_fas") as g:
+            g.return_value = True
+            eq_(self.rule.matches(msg), set(['ralph']))

--- a/tests/test_rule_matching.py
+++ b/tests/test_rule_matching.py
@@ -53,7 +53,9 @@ class TestRuleMatching(unittest.TestCase):
 
         with patch("datanommer.models.Message.grep") as f:
             f.return_value = 1, 1, query
-            eq_(rule.matches(msg), set(['hadess']))
+            with patch("fedbadges.rules.user_exists_in_fas") as g:
+                g.return_value = True
+                eq_(rule.matches(msg), set(['hadess']))
 
     def test_full_simple_match_almost_succeed(self):
         """ A simple integration test for messages with zero users """
@@ -133,7 +135,9 @@ class TestRuleMatching(unittest.TestCase):
 
         with patch("datanommer.models.Message.grep") as f:
             f.return_value = 1, 1, query
-            eq_(rule.matches(msg), set(['toshio']))
+            with patch("fedbadges.rules.user_exists_in_fas") as g:
+                g.return_value = True
+                eq_(rule.matches(msg), set(['toshio']))
 
     def test_yaml_specified_awardee_failure(self):
         """ Test that when we don't override msg2usernames, we get 2 awardees.
@@ -170,7 +174,9 @@ class TestRuleMatching(unittest.TestCase):
 
         with patch("datanommer.models.Message.grep") as f:
             f.return_value = 1, 1, query
-            eq_(rule.matches(msg), set(['toshio', 'ralph']))
+            with patch("fedbadges.rules.user_exists_in_fas") as g:
+                g.return_value = True
+                eq_(rule.matches(msg), set(['toshio', 'ralph']))
 
     def test_against_duplicates(self):
         """ Test that matching fails if user already has the badge. """
@@ -220,7 +226,9 @@ class TestRuleMatching(unittest.TestCase):
 
         with patch("datanommer.models.Message.grep") as f:
             f.return_value = 1, 1, datanommer_query
-            eq_(rule.matches(msg), set(['ralph']))
+            with patch("fedbadges.rules.user_exists_in_fas") as g:
+                g.return_value = True
+                eq_(rule.matches(msg), set(['ralph']))
 
 
 _example_real_bodhi_message = {


### PR DESCRIPTION
This should:
- fix #16
- fix fedora-infra/tahrir#225
