### PR TITLE
Don't let pkgdb2 errors turn into false positives.

### DIFF
--- a/fedbadges/rules.py
+++ b/fedbadges/rules.py
@@ -206,7 +206,11 @@ class BadgeRule(object):
             return awardees
 
         # Check our backend criteria -- likely, perform datanommer queries.
-        if not self.criteria.matches(msg):
+        try:
+            if not self.criteria.matches(msg):
+                return set()
+        except IOError as e:
+            log.exception(e)
             return set()
 
         # Lastly, and this is probably most expensive.  Make sure the person

--- a/fedbadges/utils.py
+++ b/fedbadges/utils.py
@@ -159,7 +159,8 @@ def _get_pkgdb2_packages_for(config, username):
         )
 
         if not req.status_code == 200:
-            return None
+            raise IOError("Couldn't talk to pkgdb2 for %r, %r, %r" % (
+                username, req.status_code, req.text))
 
         return req.json()
 
@@ -177,9 +178,6 @@ def _get_pkgdb2_packages_for(config, username):
         # Avoid requesting the data twice the first time around
         if i != 1:
             data = _get_page(i)
-
-        if data is None:
-            continue
 
         for pkgacl in data['acls']:
             if pkgacl['status'] != 'Approved':

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,10 +1,11 @@
 import unittest
-from nose.tools import eq_
+from nose.tools import eq_, raises
 
 from fedbadges.utils import (
     construct_substitutions,
     format_args,
     single_argument_lambda_factory,
+    _get_pkgdb2_packages_for,
 )
 
 
@@ -197,3 +198,22 @@ class TestFormatArgs(unittest.TestCase):
         }
         actual = format_args(obj, subs)
         eq_(actual, target)
+
+class TestPkgdb2(unittest.TestCase):
+
+    @raises(IOError)
+    def test_wrong_url(self):
+        config = {
+            'fedbadges.rules.utils.pkgdb_url':
+                'https://admin.fedoraproject.org/pkgdb',
+        }
+        packages = _get_pkgdb2_packages_for(config, 'ralph')
+
+    # This is an integration test that won't run in KOJI
+    #def test_simple(self):
+    #    config = {
+    #        'fedbadges.rules.utils.pkgdb_url':
+    #            'https://admin.fedoraproject.org/pkgdb/api',
+    #    }
+    #    packages = _get_pkgdb2_packages_for(config, 'ralph')
+    #    self.assertIn('pkgwat', packages)


### PR DESCRIPTION
Fixes a bug found by @bochecha where he was awarded the Helping Hand badge
erroneously.

The bug starts with getting a non-200 status code from pkgdb2.  fedbadges would
then incorrectly coerce that response to mean "if pkgdb2 gave an error when
asking for USER's packages, then USER must have 0 packages".  If USER then goes
to rebuild a package they own while pkgdb2 is erroring out temporarily, then
fedbadges concluceds that USER is rebuilding a package they do not own (since
fedbadges thinks that USER owns 0 packages).

This patch adjusts it so that if an IOError is raised from one of the criteria
comparators, then badge awarding will abort all together.
