### PR TITLE
Rely on fedmsg-provided queue.

### DIFF
--- a/fedbadges/consumers.py
+++ b/fedbadges/consumers.py
@@ -158,10 +158,8 @@ class FedoraBadgesConsumer(fedmsg.consumers.FedmsgConsumer):
             raise
 
     def consume(self, msg):
-        func = functools.partial(self.deferred_consume, msg)
-        moksha.hub.reactor.reactor.callLater(self.consume_delay, func)
+        time.sleep(self.consume_delay)
 
-    def deferred_consume(self, msg):
         # Strip the moksha envelope
         msg = msg['body']
 


### PR DESCRIPTION
fedbadges implemented this little callLater mechanism a long time ago
before fedmsg and moksha provided a much more sophisticated queueing and
monitoring framework.  Inadvertently, this callLater logic actually serves to **hide** how
many messages are in the fedbadges backlog.  By removing it, we can get a
better sense of what the consumer is doing.
