### PR TITLE
Add a new email2fas flag modeled off the existing nick2fas flag.

### DIFF
--- a/fedbadges/utils.py
+++ b/fedbadges/utils.py
@@ -22,11 +22,6 @@ import fedmsg.config
 import fedmsg.encoding
 import fedmsg.meta
 
-try:
-    from fedmsg_meta_fedora_infrastructure.fasshim import nick2fas
-except ImportError as e:
-    log.warn("Could not import nick2fas: %r" % e)
-
 
 def construct_substitutions(msg):
     """ Convert a fedmsg message into a dict of substitutions. """

--- a/tests/test_rule_matching.py
+++ b/tests/test_rule_matching.py
@@ -55,7 +55,7 @@ class TestRuleMatching(unittest.TestCase):
             f.return_value = 1, 1, query
             with patch("fedbadges.rules.user_exists_in_fas") as g:
                 g.return_value = True
-                eq_(rule.matches(msg), set(['hadess']))
+                eq_(rule.matches(msg), set(['lmacken', 'hadess']))
 
     def test_full_simple_match_almost_succeed(self):
         """ A simple integration test for messages with zero users """


### PR DESCRIPTION
This will be used for awarding badges for anitya activity.  Specifically, this badge:

https://fedorahosted.org/fedora-badges/ticket/357

... because it will be triggered by messages like these:

https://apps.fedoraproject.org/datagrepper/id?id=2015-565f2c31-065d-4e1d-842c-a097ef3834ca&is_raw=true&size=extra-large

... which don't have a fas username, just an email address.

The badge yaml will look something like this:


```yaml
%YAML 1.2
---

name:           Telegraphist (Upstream Release Monitoring I)
description:    You mapped an upstream project to a Fedora package on release-monitoring.org
creator:        ralph
discussion:     https://fedorahosted.org/fedora-badges/ticket/357
image_url:      https://badges.fedoraproject.org/pngs/telegraph.png
issuer_id:      fedora-project

trigger:
  all:
  - topic: anitya.project.map.new
  - lambda: msg.get('msg', {}).get('distro', {}).get('name', None) == 'Fedora'

criteria:
  datanommer:
      filter:
        topics:
        - "%(topic)s"
      operation: count
      condition:
        greater than or equal to: 1

recipient: "%(msg.message.agent)s"
recipient_email2fas: Yes
```
