### PR TITLE
Set the consumer to consume all topics.

### DIFF
--- a/fedbadges/consumers.py
+++ b/fedbadges/consumers.py
@@ -30,7 +30,7 @@ log = logging.getLogger("moksha.hub")
 
 
 class FedoraBadgesConsumer(fedmsg.consumers.FedmsgConsumer):
-    topic = "org.fedoraproject.*"
+    topic = "*"
     config_key = "fedmsg.consumers.badges.enabled"
     consume_delay = 3
     delay_limit = 100


### PR DESCRIPTION
Previously, this didn't matter since everything was under the fedoraproject namespace.. but *now* we want to award badges for anitya activity, and they're under the ``org.release-monitoring....`` namespace.