### PR TITLE
Hardcode the version for zope.sqlalchemy to make CI run

### DIFF
--- a/.cico.pipeline
+++ b/.cico.pipeline
@@ -1,1 +1,1 @@
-fedoraInfraTox { }
+fedoraInfraTox(["epel7"]) { }

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ fedmsg
 fedmsg_meta_fedora_infrastructure
 PyYAML
 datanommer.models
-zope.sqlalchemy
+zope.sqlalchemy==0.7.7
 requests
 psutil
 moksha

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,5 @@
 envlist = py27
 
 [testenv]
-deps = .[test]
 commands = python setup.py test
 passenv = HOME


### PR DESCRIPTION
Since that's the version on EL7, we have to use that for CI for
now