### PR TITLE
add the ability to use freeipa-fas API

### DIFF
--- a/fedmsg.d/badges-global.py
+++ b/fedmsg.d/badges-global.py
@@ -29,5 +29,7 @@ config = {
         ),
     },
 
+    "fasjson": False,
+
     "fedbadges.datagrepper_url": "https://apps.fedoraproject.org/datagrepper",
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ zope.sqlalchemy
 requests
 psutil
 moksha
+fasjson-client


### PR DESCRIPTION
this commit allows fedbadges to use config in fedmsg to define whether or not
it will use fas2 or the new freeipa-backed AAA solution. accompanying PR will be sent
to the ansible repos.

Signed-off-by: Stephen Coady <scoady@redhat.com>