### PR TITLE
Filter mbs message, since that's not a real user

### DIFF
--- a/fedbadges/rules.py
+++ b/fedbadges/rules.py
@@ -227,7 +227,8 @@ class BadgeRule(object):
         awardees = frozenset([
             user for user in awardees if not (
                 user.startswith('192.168.') or
-                user.startswith('10.')
+                user.startswith('10.') or
+                user.startswith('mbs/')
             )
         ])
 


### PR DESCRIPTION
It also overload the consumer