### PR TITLE
Convert users from Github, Dist-Git and Kerberos usernames

### DIFF
--- a/fedbadges/consumers.py
+++ b/fedbadges/consumers.py
@@ -152,7 +152,7 @@ class FedoraBadgesConsumer(fedmsg.consumers.FedmsgConsumer):
         log.debug("Loading %r" % fname)
         try:
             with open(fname, 'r') as f:
-                return yaml.load(f.read())
+                return yaml.safe_load(f.read())
         except Exception as e:
             log.error("Loading %r failed with %r" % (fname, e))
             return None

--- a/fedbadges/rules.py
+++ b/fedbadges/rules.py
@@ -84,6 +84,11 @@ def distgit2fas(uri, **config):
         return m.group(1)
     return uri
 
+def krb2fas(name, **config):
+    if "/" not in name:
+        return name
+    return name.split("/")[0]
+
 operators = frozenset([
     "all",
     "any",
@@ -123,6 +128,7 @@ class BadgeRule(object):
         'recipient_openid2fas',
         'recipient_github2fas',
         'recipient_distgit2fas',
+        'recipient_krb2fas',
     ])
 
     banned_usernames = frozenset([
@@ -180,6 +186,7 @@ class BadgeRule(object):
         self.recipient_openid2fas = self._d.get('recipient_openid2fas')
         self.recipient_github2fas = self._d.get('recipient_github2fas')
         self.recipient_distgit2fas = self._d.get('recipient_distgit2fas')
+        self.recipient_krb2fas = self._d.get('recipient_krb2fas')
 
         # A sanity check before we kick things off.
         if self.recipient_nick2fas and not nick2fas:
@@ -256,6 +263,11 @@ class BadgeRule(object):
             if self.recipient_distgit2fas:
                 awardees = frozenset([
                     distgit2fas(uri, **fedmsg_config) for uri in awardees
+                ])
+
+            if self.recipient_krb2fas:
+                awardees = frozenset([
+                    krb2fas(uri, **fedmsg_config) for uri in awardees
                 ])
 
             awardees = frozenset([e for e in awardees if e is not None])

--- a/fedbadges/rules.py
+++ b/fedbadges/rules.py
@@ -60,6 +60,18 @@ def openid2fas(openid, **config):
         return m.group(1)
     return openid
 
+def github2fas(uri, **config):
+    m = re.search('^https?://api.github.com/users/([a-z][a-z0-9]+)$', uri)
+    if m:
+        return m.group(1)
+    return uri
+
+def distgit2fas(uri, **config):
+    m = re.search('^https?://src.fedoraproject.org/user/([a-z][a-z0-9]+)$', uri)
+    if m:
+        return m.group(1)
+    return uri
+
 operators = frozenset([
     "all",
     "any",
@@ -97,6 +109,8 @@ class BadgeRule(object):
         'recipient_nick2fas',
         'recipient_email2fas',
         'recipient_openid2fas',
+        'recipient_github2fas',
+        'recipient_distgit2fas',
     ])
 
     banned_usernames = frozenset([
@@ -152,6 +166,8 @@ class BadgeRule(object):
         self.recipient_nick2fas = self._d.get('recipient_nick2fas')
         self.recipient_email2fas = self._d.get('recipient_email2fas')
         self.recipient_openid2fas = self._d.get('recipient_openid2fas')
+        self.recipient_github2fas = self._d.get('recipient_github2fas')
+        self.recipient_distgit2fas = self._d.get('recipient_distgit2fas')
 
         # A sanity check before we kick things off.
         if self.recipient_nick2fas and not nick2fas:
@@ -218,6 +234,16 @@ class BadgeRule(object):
             if self.recipient_openid2fas:
                 awardees = frozenset([
                     openid2fas(openid, **fedmsg_config) for openid in awardees
+                ])
+
+            if self.recipient_github2fas:
+                awardees = frozenset([
+                    github2fas(uri, **fedmsg_config) for uri in awardees
+                ])
+
+            if self.recipient_distgit2fas:
+                awardees = frozenset([
+                    distgit2fas(uri, **fedmsg_config) for uri in awardees
                 ])
         else:
             awardees = fedmsg.meta.msg2usernames(msg)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -22,6 +22,8 @@ class MockHub(object):
         },
         "datanommer.sqlalchemy.url": "sqlite://",
         "validate_signatures": "False",
+        "keytab": "/etc/krb5.keytab",
+        "fasjson_base_url": "https://fasjson.example.com/v1/",
     }
 
     def subscribe(self, topic, callback):


### PR DESCRIPTION
Some users logging in from Copr appear with their Github API URL or Dist-Git URL. Convert them to usernames.